### PR TITLE
Memory optimization

### DIFF
--- a/parameters/h5_params/ttHbb_fully_hadronic/features_h5_classification.yaml
+++ b/parameters/h5_params/ttHbb_fully_hadronic/features_h5_classification.yaml
@@ -1,7 +1,8 @@
 #description: "Features for classification in ttHbb fully hadronic channel"
 input:
   # MASK required by SPANet JetReconstructionDataset (see INPUTS/Jet/MASK); derived from pt in parquet_to_h5
-  Jet: [MASK, pt, eta, phi, btag, btag_L, btag_M, btag_T, btag_XT, btag_XXT, btag_CvL, btag_CvB, btag_QvG]
+  #Jet: [MASK, pt, eta, phi, btag, btag_L, btag_M, btag_T, btag_XT, btag_XXT, btag_CvL, btag_CvB, btag_QvG]
+  Jet: [MASK, pt, eta, phi, btag_L, btag_M, btag_T]
   Met: [pt, phi]
   Event: [ht]
 

--- a/tthbb_spanet/lib/dataset/base.py
+++ b/tthbb_spanet/lib/dataset/base.py
@@ -20,7 +20,7 @@ import omegaconf
 from omegaconf import OmegaConf
 
 class Dataset:
-    def __init__(self, input_file, cfg=None, shuffle=True, reweigh=False, entrystop=None, has_data=False, label=True):
+    def __init__(self, input_file, cfg=None, shuffle=True, reweigh=False, entrystop=None, has_data=False, label=True, lazy=False):
         # Load several input files into a list
         if type(input_file) == str:
             self.input_files = [input_file]
@@ -39,7 +39,8 @@ class Dataset:
 
         self.sample_dict = defaultdict(dict)
         self.load_config()
-        self.df = self.load_input()
+        if not lazy:
+            self.df = self.load_input()
 
     def get_sample_name(self, input_file):
         '''Get the sample name from the input file name.'''
@@ -110,54 +111,44 @@ class Dataset:
                 df["event"] = ak.with_field(df.event, factor * df.event.weight, "weight")
         return df
 
+    def _process_file(self, input_file, max_events=None):
+        '''Load and process a single parquet file, applying labels and weights.'''
+        if not os.path.exists(input_file):
+            raise ValueError(f"Input file {input_file} does not exist.")
+        if not input_file.endswith(".parquet"):
+            raise ValueError(f"Input file {input_file} should have the `.parquet` extension.")
+        print("Reading file: ", input_file)
+        df = ak.from_parquet(input_file)
+        if self.has_data and "event" not in df.fields:
+            df["event"] = ak.zip({"weight": np.ones(len(df), dtype=np.float64)})
+        if self.reweigh:
+            df = self.scale_weights(df, self.get_sample_name(input_file))
+        if self.label:
+            df = self.build_labels(df, self.get_sample_name(input_file))
+            df["metadata"] = ak.zip({"year": len(df)*[self.get_year(input_file)]})
+            year = df.metadata.year
+            df["metadata"] = ak.with_field(df.metadata, year[:,0], "year")
+        if max_events is not None and len(df) > max_events:
+            df = df[:max_events]
+        return df
+
     def load_input(self):
-        '''Load the input file.'''
-        # Check if the parquet files exist
-        for input_file in self.input_files:
-            if not os.path.exists(input_file):
-                raise ValueError(f"Input file {input_file} does not exist.")
-            if not input_file.endswith(".parquet"):
-                raise ValueError(f"Input file {input_file} should have the `.parquet` extension.")
-        # Read the parquet files
+        '''Load and concatenate all input parquet files into memory.'''
         print(f"Reading {len(self.input_files)} parquet files: ", self.input_files)
         dfs = []
         remaining_entries = self.entrystop
         for input_file in self.input_files:
-            print("Reading file: ", input_file)
-            df = ak.from_parquet(input_file)
-            # For data, save weights of 1 for all events
-            if self.has_data & (not "event" in df.fields):
-                df["event"] = ak.zip({"weight": np.ones(len(df), dtype=np.float)})
-            # Reweigh the events by a factor
-            if self.reweigh:
-                df = self.scale_weights(df, self.get_sample_name(input_file))
-            # Get sample name from the input file name
-            if self.label:
-                df = self.build_labels(df, self.get_sample_name(input_file))
-                # Add metadata to the dataframe
-                df["metadata"] = ak.zip({"year": len(df)*[self.get_year(input_file)]})
-                year = df.metadata.year
-                # This is needed in order to have a 1D array with one year string per event
-                df["metadata"] = ak.with_field(df.metadata, year[:,0], "year")
-
-            # If entrystop is set, cap per-file contribution and stop reading
-            # once enough events are collected.
-            if remaining_entries is not None:
-                if remaining_entries <= 0:
-                    break
-                if len(df) > remaining_entries:
-                    df = df[:remaining_entries]
-                remaining_entries -= len(df)
-
-            dfs.append(df)
             if remaining_entries is not None and remaining_entries <= 0:
                 break
+            df = self._process_file(input_file, remaining_entries)
+            if remaining_entries is not None:
+                remaining_entries -= len(df)
+            dfs.append(df)
 
         if len(dfs) == 0:
             raise ValueError("No events were loaded from input parquet files.")
-        # Return the concatenated dataframe
-        # If shuffle is True, the events are randomly shuffled
         df_concat = ak.concatenate(dfs) if len(dfs) > 1 else dfs[0]
+        del dfs
         if self.shuffle:
             df_concat = df_concat[np.random.permutation(len(df_concat))]
         if self.entrystop:

--- a/tthbb_spanet/lib/dataset/base.py
+++ b/tthbb_spanet/lib/dataset/base.py
@@ -15,6 +15,7 @@ except Exception:
 import numpy as np
 import awkward as ak
 import h5py
+import pyarrow.parquet as pq
 
 import omegaconf
 from omegaconf import OmegaConf
@@ -111,14 +112,14 @@ class Dataset:
                 df["event"] = ak.with_field(df.event, factor * df.event.weight, "weight")
         return df
 
-    def _process_file(self, input_file, max_events=None):
-        '''Load and process a single parquet file, applying labels and weights.'''
+    def _validate_input_file(self, input_file):
         if not os.path.exists(input_file):
             raise ValueError(f"Input file {input_file} does not exist.")
         if not input_file.endswith(".parquet"):
             raise ValueError(f"Input file {input_file} should have the `.parquet` extension.")
-        print("Reading file: ", input_file)
-        df = ak.from_parquet(input_file)
+
+    def _apply_df_processing(self, df, input_file):
+        '''Apply labels, weights and metadata to a (possibly partial) awkward array.'''
         if self.has_data and "event" not in df.fields:
             df["event"] = ak.zip({"weight": np.ones(len(df), dtype=np.float64)})
         if self.reweigh:
@@ -128,9 +129,54 @@ class Dataset:
             df["metadata"] = ak.zip({"year": len(df)*[self.get_year(input_file)]})
             year = df.metadata.year
             df["metadata"] = ak.with_field(df.metadata, year[:,0], "year")
+        return df
+
+    def _process_file(self, input_file, max_events=None):
+        '''Load and process a single parquet file, applying labels and weights.'''
+        self._validate_input_file(input_file)
+        print("Reading file: ", input_file)
+        df = ak.from_parquet(input_file)
+        df = self._apply_df_processing(df, input_file)
         if max_events is not None and len(df) > max_events:
             df = df[:max_events]
         return df
+
+    def _iter_file_batches(self, input_file, max_events=None, batch_size=None):
+        '''Yield processed batches of a parquet file one row-group group at a time.
+
+        If batch_size is None, one row group is read per batch. Otherwise, enough
+        consecutive row groups are concatenated to approximate batch_size events
+        (using the file's average row-group size).
+        '''
+        self._validate_input_file(input_file)
+
+        pf = pq.ParquetFile(input_file)
+        num_rg = pf.num_row_groups
+        total_rows = pf.metadata.num_rows
+
+        if num_rg == 0:
+            return
+
+        if batch_size is None:
+            rg_per_batch = 1
+        else:
+            avg_rg_rows = total_rows / num_rg
+            rg_per_batch = max(1, int(round(batch_size / avg_rg_rows)))
+
+        print(f"Reading file: {input_file} "
+              f"({num_rg} row groups, {total_rows} events, {rg_per_batch} row-group(s)/batch)")
+
+        yielded = 0
+        for start in range(0, num_rg, rg_per_batch):
+            if max_events is not None and yielded >= max_events:
+                break
+            end = min(start + rg_per_batch, num_rg)
+            df = ak.from_parquet(input_file, row_groups=list(range(start, end)))
+            df = self._apply_df_processing(df, input_file)
+            if max_events is not None and yielded + len(df) > max_events:
+                df = df[:max_events - yielded]
+            yielded += len(df)
+            yield df
 
     def load_input(self):
         '''Load and concatenate all input parquet files into memory.'''

--- a/tthbb_spanet/lib/dataset/spanet_dataset.py
+++ b/tthbb_spanet/lib/dataset/spanet_dataset.py
@@ -24,13 +24,16 @@ class SpecialKey(str, Enum):
     Weights = "WEIGHTS"
 
 class SPANetDataset(Dataset):
-    def __init__(self, input_file, cfg, shuffle=True, reweigh=False, entrystop=None, has_data=False, fully_matched=False, enable_streaming=True):
+    def __init__(self, input_file, cfg, shuffle=True, reweigh=False, entrystop=None, has_data=False,
+                 fully_matched=False, enable_streaming=True, batch_size=None, shuffle_output=True):
         # Streaming mode processes one file at a time and never loads all data into RAM.
         # It requires no pre-loaded df, so use lazy=True only when streaming is active
         # and fully_matched is off (fully_matched needs all data in memory to apply its filter).
         self.enable_streaming = enable_streaming
         self.fully_matched = fully_matched
-        lazy = enable_streaming
+        self.batch_size = batch_size
+        self.shuffle_output = shuffle_output
+        lazy = enable_streaming and not fully_matched
         super().__init__(input_file, cfg, shuffle=shuffle, reweigh=reweigh, entrystop=entrystop, has_data=has_data, lazy=lazy)
         # base.__init__ already calls load_input() when lazy=False, so self.df is set.
         # fully_matched=True forces lazy=False above, so the data is available here.
@@ -288,15 +291,16 @@ class SPANetDataset(Dataset):
             self.file.close()
 
     def _save_streaming(self, output_file):
-        '''Memory-efficient save: processes one parquet file at a time.
+        '''Memory-efficient save using batched parquet reads and per-file train/test split.
 
-        Instead of loading all files into RAM and then writing, this method reads
-        event counts from parquet metadata (zero data loading), pre-computes the
-        train/test split, then processes each file individually — loading, writing
-        to h5, and immediately freeing the data before moving to the next file.
+        For each input parquet file (each typically corresponds to a different physical
+        process), events are streamed in row-group batches and split into train/test
+        according to ``test_size``. This guarantees every process is proportionally
+        represented in both splits regardless of file order.
 
-        Shuffle is applied per-file (and file order is randomised when shuffle=True),
-        which is a good approximation of a global shuffle without the memory cost.
+        If ``shuffle`` and ``shuffle_output`` are both True, the resulting h5 files are
+        globally shuffled at the end (one dataset at a time, peak RAM ≈ size of the
+        largest dataset).
         '''
         # Count events from parquet metadata without loading any column data.
         file_counts = []
@@ -312,14 +316,12 @@ class SPANetDataset(Dataset):
 
         files = self.input_files[:len(file_counts)]
 
-        if self.shuffle:
-            order = np.random.permutation(len(files))
-            files = [files[i] for i in order]
-            file_counts = [file_counts[i] for i in order]
-
-        total = sum(file_counts)
-        n_train = int((1 - self.test_size) * total)
-        n_test = total - n_train
+        # Per-file train budget: each file contributes the same fraction to train,
+        # so every physical process is proportionally split between train and test.
+        file_train_budgets = [int((1 - self.test_size) * n) for n in file_counts]
+        n_train = sum(file_train_budgets)
+        n_test = sum(file_counts) - n_train
+        total = n_train + n_test
 
         print(f"Total events: {total}, train: {n_train}, test: {n_test}")
 
@@ -339,30 +341,60 @@ class SPANetDataset(Dataset):
                 self.file = h5
                 self.create_groups()
 
-            train_budget = n_train
+            for file_path, max_events, train_budget in zip(files, file_counts, file_train_budgets):
+                remaining_train = train_budget
+                for batch in self._iter_file_batches(file_path, max_events=max_events, batch_size=self.batch_size):
+                    n_batch = len(batch)
+                    n_batch_train = min(remaining_train, n_batch)
+                    n_batch_test = n_batch - n_batch_train
+                    remaining_train -= n_batch_train
 
-            for file_path, max_events in zip(files, file_counts):
-                df = self._process_file(file_path, max_events)
+                    if n_batch_train > 0:
+                        self._append_chunk(h5_train, batch[:n_batch_train])
+                    if n_batch_test > 0:
+                        self._append_chunk(h5_test, batch[n_batch_train:])
 
-                if self.shuffle:
-                    df = df[np.random.permutation(len(df))]
-
-                n_file_train = min(train_budget, len(df))
-                n_file_test = len(df) - n_file_train
-                train_budget -= n_file_train
-
-                if n_file_train > 0:
-                    self._append_chunk(h5_train, df[:n_file_train])
-                if n_file_test > 0:
-                    self._append_chunk(h5_test, df[n_file_train:])
-
-                del df
-                gc.collect()
+                    del batch
+                    gc.collect()
 
             for h5 in [h5_train, h5_test]:
                 print(h5)
                 self.file = h5
                 self.print()
+
+        # Global shuffle of each h5 file (one dataset at a time).
+        if self.shuffle and self.shuffle_output:
+            print("Shuffling output h5 files...")
+            self._shuffle_h5(train_path)
+            self._shuffle_h5(test_path)
+
+    def _shuffle_h5(self, h5_path):
+        '''Globally shuffle every dataset in an h5 file in place using a shared permutation.
+
+        Loads one dataset at a time. Peak extra RAM ≈ 2 × size of the largest dataset
+        (the loaded copy plus the fancy-indexed permuted copy).
+        '''
+        with h5py.File(h5_path, "r+") as f:
+            dataset_names = []
+            f.visititems(lambda name, obj: dataset_names.append(name) if isinstance(obj, h5py.Dataset) else None)
+
+            if not dataset_names:
+                return
+
+            n = f[dataset_names[0]].shape[0]
+            for name in dataset_names:
+                if f[name].shape[0] != n:
+                    raise RuntimeError(f"Dataset {name} has size {f[name].shape[0]}, expected {n}.")
+
+            perm = np.random.permutation(n)
+            print(f"  {h5_path}: shuffling {len(dataset_names)} datasets ({n} events)")
+
+            for name in dataset_names:
+                ds = f[name]
+                data = ds[:]
+                ds[:] = data[perm]
+                del data
+                gc.collect()
 
     def _append_chunk(self, h5_file, df):
         '''Append one chunk of events to h5, creating resizable datasets on first write.'''

--- a/tthbb_spanet/lib/dataset/spanet_dataset.py
+++ b/tthbb_spanet/lib/dataset/spanet_dataset.py
@@ -1,10 +1,12 @@
 import os
+import gc
 from enum import Enum
 from collections import defaultdict
 
 import numpy as np
 import awkward as ak
 import h5py
+import pyarrow.parquet as pq
 
 from .base import Dataset
 
@@ -22,9 +24,16 @@ class SpecialKey(str, Enum):
     Weights = "WEIGHTS"
 
 class SPANetDataset(Dataset):
-    def __init__(self, input_file, cfg, shuffle=True, reweigh=False, entrystop=None, has_data=False, fully_matched=False):
-        super().__init__(input_file, cfg, shuffle=shuffle, reweigh=reweigh, entrystop=entrystop, has_data=has_data)
+    def __init__(self, input_file, cfg, shuffle=True, reweigh=False, entrystop=None, has_data=False, fully_matched=False, enable_streaming=True):
+        # Streaming mode processes one file at a time and never loads all data into RAM.
+        # It requires no pre-loaded df, so use lazy=True only when streaming is active
+        # and fully_matched is off (fully_matched needs all data in memory to apply its filter).
+        self.enable_streaming = enable_streaming
         self.fully_matched = fully_matched
+        lazy = enable_streaming
+        super().__init__(input_file, cfg, shuffle=shuffle, reweigh=reweigh, entrystop=entrystop, has_data=has_data, lazy=lazy)
+        # base.__init__ already calls load_input() when lazy=False, so self.df is set.
+        # fully_matched=True forces lazy=False above, so the data is available here.
         if self.fully_matched:
             self.select_fully_matched()
 
@@ -252,6 +261,13 @@ class SPANetDataset(Dataset):
 
     def save(self, output_file):
         '''Save the h5 file for both the training and testing datasets.'''
+        if self.enable_streaming:
+            self._save_streaming(output_file)
+        else:
+            self._save_in_memory(output_file)
+
+    def _save_in_memory(self, output_file):
+        '''Save using the full in-memory dataset (used when fully_matched=True).'''
         for dataset_type in ["train", "test"]:
             print(f"Processing dataset: {dataset_type} ({len(getattr(self, dataset_type))} events)")
 
@@ -270,3 +286,154 @@ class SPANetDataset(Dataset):
             print(self.file)
             self.print()
             self.file.close()
+
+    def _save_streaming(self, output_file):
+        '''Memory-efficient save: processes one parquet file at a time.
+
+        Instead of loading all files into RAM and then writing, this method reads
+        event counts from parquet metadata (zero data loading), pre-computes the
+        train/test split, then processes each file individually — loading, writing
+        to h5, and immediately freeing the data before moving to the next file.
+
+        Shuffle is applied per-file (and file order is randomised when shuffle=True),
+        which is a good approximation of a global shuffle without the memory cost.
+        '''
+        # Count events from parquet metadata without loading any column data.
+        file_counts = []
+        remaining = self.entrystop
+        for f in self.input_files:
+            n = pq.read_metadata(f).num_rows
+            if remaining is not None:
+                n = min(n, remaining)
+                remaining -= n
+            file_counts.append(n)
+            if remaining is not None and remaining <= 0:
+                break
+
+        files = self.input_files[:len(file_counts)]
+
+        if self.shuffle:
+            order = np.random.permutation(len(files))
+            files = [files[i] for i in order]
+            file_counts = [file_counts[i] for i in order]
+
+        total = sum(file_counts)
+        n_train = int((1 - self.test_size) * total)
+        n_test = total - n_train
+
+        print(f"Total events: {total}, train: {n_train}, test: {n_test}")
+
+        train_path = output_file.replace(".h5", f"_train_{n_train}.h5")
+        test_path = output_file.replace(".h5", f"_test_{n_test}.h5")
+        self.check_output(train_path)
+        self.check_output(test_path)
+
+        print(f"Creating output files:")
+        print(f"    - {train_path}")
+        print(f"    - {test_path}")
+
+        with h5py.File(train_path, "w") as h5_train, \
+             h5py.File(test_path, "w") as h5_test:
+
+            for h5 in [h5_train, h5_test]:
+                self.file = h5
+                self.create_groups()
+
+            train_budget = n_train
+
+            for file_path, max_events in zip(files, file_counts):
+                df = self._process_file(file_path, max_events)
+
+                if self.shuffle:
+                    df = df[np.random.permutation(len(df))]
+
+                n_file_train = min(train_budget, len(df))
+                n_file_test = len(df) - n_file_train
+                train_budget -= n_file_train
+
+                if n_file_train > 0:
+                    self._append_chunk(h5_train, df[:n_file_train])
+                if n_file_test > 0:
+                    self._append_chunk(h5_test, df[n_file_train:])
+
+                del df
+                gc.collect()
+
+            for h5 in [h5_train, h5_test]:
+                print(h5)
+                self.file = h5
+                self.print()
+
+    def _append_chunk(self, h5_file, df):
+        '''Append one chunk of events to h5, creating resizable datasets on first write.'''
+        n = len(df)
+
+        def append(name, data, dtype=None):
+            arr = np.asarray(data, dtype=dtype)
+            if name in h5_file:
+                ds = h5_file[name]
+                old = ds.shape[0]
+                ds.resize(old + n, axis=0)
+                ds[old:old + n] = arr
+            else:
+                maxshape = (None,) + arr.shape[1:]
+                h5_file.create_dataset(name, data=arr, maxshape=maxshape, chunks=True)
+
+        # Targets
+        if not self.has_data:
+            jets = df[self.collection["Jet"]]
+            indices = ak.local_index(jets)
+            has_prov = "prov" in jets.fields
+
+            for target in self.targets:
+                if target == "h":
+                    if has_prov:
+                        mask = jets.prov == 1
+                        idx = ak.fill_none(ak.pad_none(indices[mask], 2), -1)
+                        append(f"TARGETS/h/b1", ak.to_numpy(idx[:, 0]), np.int64)
+                        append(f"TARGETS/h/b2", ak.to_numpy(idx[:, 1]), np.int64)
+                    else:
+                        append(f"TARGETS/h/b1", -np.ones(n, dtype=np.int64))
+                        append(f"TARGETS/h/b2", -np.ones(n, dtype=np.int64))
+                elif target == "t1":
+                    if has_prov:
+                        idx_q = ak.fill_none(ak.pad_none(indices[jets.prov == 5], 2), -1)
+                        idx_b = ak.fill_none(ak.pad_none(indices[jets.prov == 2], 1), -1)[:, 0]
+                        append(f"TARGETS/t1/q1", ak.to_numpy(idx_q[:, 0]), np.int64)
+                        append(f"TARGETS/t1/q2", ak.to_numpy(idx_q[:, 1]), np.int64)
+                        append(f"TARGETS/t1/b",  ak.to_numpy(idx_b), np.int64)
+                    else:
+                        append(f"TARGETS/t1/q1", -np.ones(n, dtype=np.int64))
+                        append(f"TARGETS/t1/q2", -np.ones(n, dtype=np.int64))
+                        append(f"TARGETS/t1/b",  -np.ones(n, dtype=np.int64))
+                elif target == "t2":
+                    if has_prov:
+                        idx_q = ak.fill_none(ak.pad_none(indices[jets.prov == 6], 2), -1)
+                        idx_b = ak.fill_none(ak.pad_none(indices[jets.prov == 3], 1), -1)[:, 0]
+                        append(f"TARGETS/t2/q1", ak.to_numpy(idx_q[:, 0]), np.int64)
+                        append(f"TARGETS/t2/q2", ak.to_numpy(idx_q[:, 1]), np.int64)
+                        append(f"TARGETS/t2/b",  ak.to_numpy(idx_b), np.int64)
+                    else:
+                        append(f"TARGETS/t2/q1", -np.ones(n, dtype=np.int64))
+                        append(f"TARGETS/t2/q2", -np.ones(n, dtype=np.int64))
+                        append(f"TARGETS/t2/b",  -np.ones(n, dtype=np.int64))
+                else:
+                    raise NotImplementedError
+
+        # Classifications
+        for group, targets in self.classification_targets.items():
+            for target in targets:
+                if group == SpecialKey.Event.value:
+                    append(f"CLASSIFICATIONS/{group}/{target}", ak.to_numpy(df[target]), np.int64)
+                else:
+                    raise NotImplementedError
+
+        # Inputs
+        features = self.get_object_features(df)
+        for obj, feats in features.items():
+            for feat, val in feats.items():
+                dtype = bool if feat == "MASK" else np.float32
+                append(f"INPUTS/{obj}/{feat}", val, dtype)
+
+        # Weights
+        append("WEIGHTS/weight", ak.to_numpy(df.event.weight), np.float32)

--- a/tthbb_spanet/scripts/dataset/merge_h5_files.py
+++ b/tthbb_spanet/scripts/dataset/merge_h5_files.py
@@ -1,92 +1,166 @@
 import os
+import gc
 import argparse
 import h5py
 import numpy as np
 
-# Function to recursively read datasets from groups and subgroups
-def read_data(group):
-    data = {}
+
+def collect_schema(group, prefix=""):
+    """Walk an h5 group and return a list of (path, shape, dtype, chunks) tuples for every dataset."""
+    out = []
     for key, item in group.items():
+        path = f"{prefix}/{key}"
         if isinstance(item, h5py.Dataset):
-            data[key] = item[:]
+            out.append((path, item.shape, item.dtype, item.chunks))
         elif isinstance(item, h5py.Group):
-            data[key] = read_data(item)
-    return data
+            out.extend(collect_schema(item, path))
+    return out
 
-# Function to recursively concatenate datasets from multiple files
-def concatenate_data(data_list):
-    if isinstance(data_list[0], np.ndarray):
-        return np.concatenate(data_list, axis=0)
-    concatenated = {}
-    for key in data_list[0].keys():
-        concatenated[key] = concatenate_data([data[key] for data in data_list])
-    return concatenated
 
-# Function to recursively shuffle datasets
-def shuffle_data(data, indices):
-    if isinstance(data, np.ndarray):
-        return data[indices]
-    shuffled = {}
-    for key in data.keys():
-        shuffled[key] = shuffle_data(data[key], indices)
-    return shuffled
+def ensure_group(h5file, path):
+    """Create intermediate groups for a dataset path like '/A/B/name' and return the parent group."""
+    parts = [p for p in path.split("/") if p]
+    parent = h5file
+    for p in parts[:-1]:
+        parent = parent.require_group(p)
+    return parent, parts[-1]
 
-# Function to recursively write datasets to groups and subgroups
-def write_data(group, data):
-    for key, item in data.items():
-        if isinstance(item, np.ndarray):
-            group.create_dataset(key, data=item)
-        else:
-            subgroup = group.create_group(key)
-            write_data(subgroup, item)
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-i", "--input", nargs="+", help="Input h5 files", required=True)
-parser.add_argument("-o", "--output", help="Output file", required=True)
-parser.add_argument("--no-shuffle", action="store_true", help="Do not shuffle the data")
-parser.add_argument("--overwrite", action="store_true", help="Overwrite the output file if it already exists")
-args = parser.parse_args()
+def fill_buffer_from_inputs(input_files, path, row_counts, file_offsets, buf, read_chunk):
+    """Read the same dataset path from each input file and place it into buf at the right offset."""
+    for i, f_path in enumerate(input_files):
+        n = row_counts[i]
+        offset = file_offsets[i]
+        with h5py.File(f_path, "r") as in_f:
+            ds = in_f[path]
+            if ds.shape[0] != n:
+                raise Exception(
+                    f"Dataset {path} in {f_path} has {ds.shape[0]} rows, "
+                    f"expected {n} (mismatch with reference dataset in same file)."
+                )
+            # Stream the read in chunks to keep peak memory bounded even for huge inputs.
+            for s in range(0, n, read_chunk):
+                e = min(s + read_chunk, n)
+                ds.read_direct(buf, np.s_[s:e], np.s_[offset + s:offset + e])
 
-# Check if the input files exist
-for f in args.input:
-    if not os.path.exists(f):
-        raise Exception(f"Input file {f} does not exist")
-# Create output folder if it does not exist
-os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
 
-# Check if the output file is in h5 format
-if not args.output.endswith(".h5"):
-    raise Exception("Output file must be in h5 format")
+def write_dataset(out_f, path, buf, perm, chunks, write_chunk):
+    """Create a dataset in out_f at `path` and write buf, applying `perm` if given."""
+    parent, name = ensure_group(out_f, path)
+    out_ds = parent.create_dataset(name, shape=buf.shape, dtype=buf.dtype, chunks=chunks)
+    if perm is None:
+        # Sequential write in chunks (avoids h5py shipping the full array in one call).
+        total = buf.shape[0]
+        for s in range(0, total, write_chunk):
+            e = min(s + write_chunk, total)
+            out_ds[s:e] = buf[s:e]
+    else:
+        total = buf.shape[0]
+        for s in range(0, total, write_chunk):
+            e = min(s + write_chunk, total)
+            # out[s:e] = buf[perm[s:e]]  -> sequential output write, gather-read from buf.
+            out_ds[s:e] = buf[perm[s:e]]
 
-# Read data from all files
-all_data = []
-for file_path in args.input:
-    with h5py.File(file_path, 'r') as f:
-        all_data.append(read_data(f))
 
-# Concatenate data from all files
-combined_data = concatenate_data(all_data)
-num_entries = len(combined_data["WEIGHTS"]["weight"])  # Assuming all top-level groups have the same number of entries
-args.output = args.output.replace(".h5", f"_{num_entries}.h5")
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", nargs="+", help="Input h5 files", required=True)
+    parser.add_argument("-o", "--output", help="Output file", required=True)
+    parser.add_argument("--no-shuffle", action="store_true", help="Do not shuffle the data")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite the output file if it already exists")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for the shuffle permutation")
+    parser.add_argument("--read-chunk", type=int, default=1_000_000,
+                        help="Rows to read per input slice (per dataset). Default: 1,000,000")
+    parser.add_argument("--write-chunk", type=int, default=1_000_000,
+                        help="Rows to write per output slice (per dataset). Default: 1,000,000")
+    return parser.parse_args()
 
-# Shuffle the combined data
-if not args.no_shuffle:
-    print("Shuffling the data")
-    # Generate a list of indices and shuffle it
-    shuffled_indices = np.random.permutation(num_entries)
-    # Shuffle the combined data using the shuffled indices
-    combined_data = shuffle_data(combined_data, shuffled_indices)
 
-# Check if the output file already exists
-if not args.overwrite and os.path.exists(args.output):
-    raise Exception(f"Output file {args.output} already exists")
+def main():
+    args = parse_args()
 
-# Write the shuffled data to the new h5 file
-print("Writing the data to the output file")
-with h5py.File(args.output, 'w') as f:
-    write_data(f, combined_data)
+    for f in args.input:
+        if not os.path.exists(f):
+            raise Exception(f"Input file {f} does not exist")
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    if not args.output.endswith(".h5"):
+        raise Exception("Output file must be in h5 format")
 
-msg = f"Data from {args.input} has been merged into {args.output}"
-if not args.no_shuffle:
-    msg = msg.replace("merged", "merged and shuffled")
-print(msg)
+    # Pass 1: build the reference schema from the first file and collect row counts.
+    print("Scanning input files...")
+    with h5py.File(args.input[0], "r") as f:
+        reference_schema = collect_schema(f)
+    if not reference_schema:
+        raise Exception(f"No datasets found in {args.input[0]}")
+    ref_paths = {p: (s[1:], np.dtype(d)) for p, s, d, _ in reference_schema}
+
+    # The leading dim of the first dataset in the reference is treated as the event count.
+    row_counts = []
+    for f_path in args.input:
+        with h5py.File(f_path, "r") as f:
+            schema = collect_schema(f)
+            these = {p: (s[1:], np.dtype(d)) for p, s, d, _ in schema}
+            if these.keys() != ref_paths.keys():
+                missing = ref_paths.keys() - these.keys()
+                extra = these.keys() - ref_paths.keys()
+                raise Exception(
+                    f"Schema mismatch in {f_path}: missing={sorted(missing)}, extra={sorted(extra)}"
+                )
+            for p, (tail, dt) in ref_paths.items():
+                if these[p] != (tail, dt):
+                    raise Exception(
+                        f"Schema mismatch for {p} in {f_path}: "
+                        f"got tail={these[p][0]} dtype={these[p][1]}, "
+                        f"expected tail={tail} dtype={dt}"
+                    )
+            n = schema[0][1][0]
+            for p, s, _, _ in schema:
+                if s[0] != n:
+                    raise Exception(
+                        f"In {f_path}, dataset {p} has leading dim {s[0]}, "
+                        f"expected {n} (all datasets must be event-aligned)."
+                    )
+            row_counts.append(n)
+            print(f"  {f_path}: {n} events")
+
+    total = int(sum(row_counts))
+    file_offsets = np.cumsum([0] + row_counts[:-1]).astype(np.int64)
+    print(f"Total events: {total}")
+
+    # Update the output path with the total count, matching the original convention.
+    args.output = args.output.replace(".h5", f"_{total}.h5")
+    if not args.overwrite and os.path.exists(args.output):
+        raise Exception(f"Output file {args.output} already exists")
+
+    # Build the permutation once (int64; ~8 bytes/event -> ~750 MB for 93M events).
+    if args.no_shuffle:
+        perm = None
+    else:
+        print("Generating shuffle permutation")
+        rng = np.random.default_rng(args.seed)
+        perm = rng.permutation(total)
+
+    # Pass 2: stream one dataset at a time through a merged buffer.
+    print(f"Writing to {args.output}")
+    with h5py.File(args.output, "w") as out_f:
+        for path, ref_shape, dtype, ref_chunks in reference_schema:
+            tail = tuple(ref_shape[1:])
+            shape = (total,) + tail
+            nbytes = int(np.prod(shape)) * np.dtype(dtype).itemsize
+            print(f"  {path}: shape={shape} dtype={dtype} ({nbytes / 1e9:.2f} GB)")
+            buf = np.empty(shape, dtype=dtype)
+            try:
+                fill_buffer_from_inputs(
+                    args.input, path, row_counts, file_offsets, buf, args.read_chunk,
+                )
+                write_dataset(out_f, path, buf, perm, ref_chunks, args.write_chunk)
+            finally:
+                del buf
+                gc.collect()
+
+    action = "merged" if args.no_shuffle else "merged and shuffled"
+    print(f"Data from {len(args.input)} files has been {action} into {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tthbb_spanet/scripts/dataset/parquet_to_h5.py
+++ b/tthbb_spanet/scripts/dataset/parquet_to_h5.py
@@ -11,16 +11,22 @@ if __name__ == '__main__':
     parser.add_argument('--no_shuffle', action='store_true', help='If set, do not shuffle the dataset')
     parser.add_argument('--reweigh', action='store_true', help='If set, scale event weights by a factor as specified in the configuration file')
     parser.add_argument('--entrystop', type=int, default=None, required=False, help='Number of events to process')
+    parser.add_argument('--batch_size', type=int, default=None, required=False,
+                        help='Target number of events per batch when reading parquet (rounded to a whole number of row groups). Default: one row group per batch.')
+    parser.add_argument('--no_shuffle_output', action='store_true',
+                        help='Skip the final global shuffle of the output h5 files (saves RAM at the cost of leaving the data sorted by input file).')
 
     args = parser.parse_args()
 
     dataset = SPANetDataset(
         args.input,
         args.cfg,
-        (not args.no_shuffle),
-        args.reweigh,
-        args.entrystop,
-        False,
-        args.fully_matched
+        shuffle=(not args.no_shuffle),
+        reweigh=args.reweigh,
+        entrystop=args.entrystop,
+        has_data=False,
+        fully_matched=args.fully_matched,
+        batch_size=args.batch_size,
+        shuffle_output=(not args.no_shuffle_output),
     )
     dataset.save(args.output)


### PR DESCRIPTION
This pull request refactors the dataset loading and saving pipeline to support memory-efficient streaming of large parquet files and to provide flexible train/test splitting and shuffling. It introduces batch-wise reading and writing, per-process proportional splits, and global output shuffling, while maintaining compatibility with the existing in-memory workflow. It also updates the feature list for the classification task.

**Major improvements to dataset streaming and memory usage:**

* Added a streaming mode to `SPANetDataset` and `Dataset` classes, which processes input parquet files in batches (row groups) rather than loading all data into RAM at once. This is controlled via the `enable_streaming` and `batch_size` parameters. [[1]](diffhunk://#diff-107c752c861c438c16acc21f9d36dce52c50f5861e760f7bee8f70c3cebdfd64R18-R24) [[2]](diffhunk://#diff-d9d8107caf208696b2ee8994e7bbd7f957a654a1b5208c0150b6de26188953a3L25-R39)
* Implemented `_iter_file_batches` and related helpers in `Dataset` to yield processed data in batches, enabling efficient handling of large datasets.
* In streaming mode, the `save` method now writes train and test splits directly to HDF5 files per batch, ensuring proportional representation from each process and minimizing memory usage.

**Output file handling and shuffling:**

* Added global shuffling of output HDF5 files (optional) after all data has been written, ensuring randomized order for downstream training. This is done efficiently, loading one dataset at a time.

**Feature selection update:**

* Updated the jet features used for classification in `features_h5_classification.yaml`, reducing the list to only `MASK`, `pt`, `eta`, `phi`, `btag_L`, `btag_M`, and `btag_T` for a more focused input set.

These changes make the data pipeline scalable to much larger datasets, reduce peak memory usage, and improve reproducibility and flexibility of train/test splits.